### PR TITLE
dota2 app id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["api", "bot", "sandbox"]
+default-members = ["bot"]
 resolver = "2"

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -239,10 +239,11 @@ impl HttpClient {
 
     pub async fn fetch_market_data<T: DeserializeOwned>(
         &self,
+        app_id: i32,
         skin_id: i32,
         offset: usize,
     ) -> Result<T> {
-        let url = format!("{BASE_URL}/market/search/{CS2_APP_ID}");
+        let url = format!("{BASE_URL}/market/search/{app_id}");
 
         let payload = json!({
             "where": { "skin_id": [skin_id] },

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -13,7 +13,7 @@ const BASE_URL: &str = "https://api.bitskins.com";
 const MAX_LIMIT: usize = 500;
 
 pub const CS2_APP_ID: i32 = 730;
-pub const DOTA2_APP_ID: i32 = 470;
+pub const DOTA2_APP_ID: i32 = 570;
 
 fn deserialize_sqlx_date<'de, D>(deserializer: D) -> Result<Date, D::Error>
 where
@@ -128,35 +128,35 @@ impl HttpClient {
         }
     }
 
-    pub async fn delist_item(&self, id: &str) -> Result<()> {
+    pub async fn delist_item(&self, app_id: i32, item_id: &str) -> Result<()> {
         let url = format!("{BASE_URL}/market/delist/single");
 
         let payload = json!({
-            "app_id": CS2_APP_ID,
-            "id": id,
+            "app_id": app_id,
+            "id": item_id,
         });
 
         self.post(url, payload).await
     }
 
-    pub async fn update_price(&self, id: &str, price: i32) -> Result<()> {
+    pub async fn update_price(&self, app_id: i32, item_id: &str, price: i32) -> Result<()> {
         let url = format!("{BASE_URL}/market/update_price/single");
 
         let payload = json!({
-            "app_id": CS2_APP_ID,
-            "id": id,
+            "app_id": app_id,
+            "id": item_id,
             "price": price,
         });
 
         self.post(url, payload).await
     }
 
-    pub async fn list_item(&self, id: &str, price: i32) -> Result<()> {
+    pub async fn list_item(&self, app_id: i32, item_id: &str, price: i32) -> Result<()> {
         let url = format!("{BASE_URL}/market/relist/single");
 
         let payload = json!({
-            "app_id": CS2_APP_ID,
-            "id": id,
+            "app_id": app_id,
+            "id": item_id,
             "price": price,
         });
 
@@ -169,12 +169,12 @@ impl HttpClient {
         self.post::<i32>(url, json!({})).await
     }
 
-    pub async fn buy_item(&self, id: &str, price: i32) -> Result<()> {
+    pub async fn buy_item(&self, app_id: i32, item_id: &str, price: i32) -> Result<()> {
         let url = format!("{BASE_URL}/market/buy/single");
 
         let payload = json!({
-            "app_id": CS2_APP_ID,
-            "id": id,
+            "app_id": app_id,
+            "id": item_id,
             "max_price": price
         });
 
@@ -208,11 +208,11 @@ impl HttpClient {
         self.request(self.client.get(url)).await
     }
 
-    pub(crate) async fn fetch_sales<T: DeserializeOwned>(&self, skin_id: i32) -> Result<T> {
+    pub(crate) async fn fetch_sales<T: DeserializeOwned>(&self, app_id: i32, skin_id: i32) -> Result<T> {
         let url = format!("{BASE_URL}/market/pricing/list");
 
         let payload = json!({
-            "app_id": CS2_APP_ID,
+            "app_id": app_id,
             "skin_id": skin_id,
             "limit": MAX_LIMIT,
         });
@@ -220,13 +220,13 @@ impl HttpClient {
         self.post(url, payload).await
     }
 
-    pub(crate) async fn fetch_skins(&self) -> Result<Vec<i32>> {
+    pub(crate) async fn fetch_skins(&self, app_id: i32) -> Result<Vec<i32>> {
         #[derive(Debug, Deserialize)]
         pub(crate) struct SkinID {
             id: i32,
         }
 
-        let url = format!("{BASE_URL}/market/skin/{CS2_APP_ID}");
+        let url = format!("{BASE_URL}/market/skin/{app_id}");
 
         let skin_ids: Vec<SkinID> = self.get(url).await?;
 

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -13,6 +13,7 @@ const BASE_URL: &str = "https://api.bitskins.com";
 const MAX_LIMIT: usize = 500;
 
 pub const CS2_APP_ID: i32 = 730;
+pub const DOTA2_APP_ID: i32 = 470;
 
 fn deserialize_sqlx_date<'de, D>(deserializer: D) -> Result<Date, D::Error>
 where

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -208,7 +208,11 @@ impl HttpClient {
         self.request(self.client.get(url)).await
     }
 
-    pub(crate) async fn fetch_sales<T: DeserializeOwned>(&self, app_id: i32, skin_id: i32) -> Result<T> {
+    pub(crate) async fn fetch_sales<T: DeserializeOwned>(
+        &self,
+        app_id: i32,
+        skin_id: i32,
+    ) -> Result<T> {
         let url = format!("{BASE_URL}/market/pricing/list");
 
         let payload = json!({

--- a/bot/src/trader.rs
+++ b/bot/src/trader.rs
@@ -8,8 +8,8 @@ const MIN_SLOPE: f64 = 0.0;
 async fn handle_purchase(http: &HttpClient, data: &WsData, mean: f64) -> anyhow::Result<()> {
     let balance = http.check_balance().await?;
     if data.price < balance {
-        http.buy_item(&data.id, data.price).await?;
-        http.list_item(&data.id, mean as i32).await?;
+        http.buy_item(data.app_id, &data.id, data.price).await?;
+        http.list_item(data.app_id, &data.id, mean as i32).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
We need our `http.rs` logic that currently uses the default `CS2_APP_ID` to also now work with `DOTA2_APP_ID`, so now `app_id` should be a parameter to these functions

**NOTE:** We would still eventually need to support it in our tables in our database, but this pull request should just be for `http.rs` for now